### PR TITLE
EP-11888 Make Collector psr-4 standard compliant

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@ composer require movenium/collector-rest-php
 Login to capi
 
 ```
-use movenium\collector;
+use Covenium\Collector;
 
-$collector = new collector();
+$collector = new Collector();
 $collector->login("username", "password");
 ```
 

--- a/src/Movenium/Collector.php
+++ b/src/Movenium/Collector.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace movenium;
+namespace Movenium;
 
-class collector {
+class Collector {
 
     var $ok_http_codes = array(200,201,204);
     var $apiurl = "https://api.movenium.com/1.1/";


### PR DESCRIPTION
Nonstandard filename and class naming causes issues with newer composer in ttapi where this repo is used as a submodule.

Filenames and class names should be in PascalCase to be compliant.