### PR TITLE
Add curl timeout and connection timeout to all requests

### DIFF
--- a/Collector.php
+++ b/Collector.php
@@ -278,6 +278,8 @@ class Collector {
 
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 60);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 
         $server_output = curl_exec ($ch);
         $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);

--- a/src/movenium/collector.php
+++ b/src/movenium/collector.php
@@ -242,6 +242,8 @@ class collector {
 
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 60);
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 
         $server_output = curl_exec ($ch);
         $httpcode = curl_getinfo($ch, CURLINFO_HTTP_CODE);


### PR DESCRIPTION
## Summary
- Set `CURLOPT_TIMEOUT` to 60 seconds on all curl requests
- Set `CURLOPT_CONNECTTIMEOUT` to 10 seconds on all curl requests
- Applied to both `Collector.php` and `src/movenium/collector.php`

## Test plan
- [ ] Verify existing functionality is unaffected (requests completing within 60s)
- [ ] Verify that requests to unresponsive hosts now fail with a curl error instead of hanging indefinitely

🤖 Generated with [Claude Code](https://claude.com/claude-code)