### PR TITLE
EP-13684 Expose curl timeout as public Collector property

### DIFF
--- a/Collector.php
+++ b/Collector.php
@@ -14,6 +14,7 @@ class Collector {
     var $default_client_id = "openapi";
     var $allow_error = false;
     var $outputFormat = null;
+    var $timeout = 60;
     var $headers = array();
     var $last_count = 0;
 
@@ -278,7 +279,7 @@ class Collector {
 
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_TIMEOUT, 60);
+        curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 
         $server_output = curl_exec ($ch);

--- a/src/movenium/collector.php
+++ b/src/movenium/collector.php
@@ -10,6 +10,7 @@ class collector {
     var $default_client_id = "openapi";
     var $allow_error = false;
     var $outputFormat = null;
+    var $timeout = 60;
     var $headers = array();
     var $last_count = 0;
 
@@ -242,7 +243,7 @@ class collector {
 
         curl_setopt($ch, CURLOPT_HTTPHEADER, $headers);
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
-        curl_setopt($ch, CURLOPT_TIMEOUT, 60);
+        curl_setopt($ch, CURLOPT_TIMEOUT, $this->timeout);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 10);
 
         $server_output = curl_exec ($ch);


### PR DESCRIPTION
Collector::request() hardcoded CURLOPT_TIMEOUT to 60 seconds, which caused ttapi/worktimesForTaxman to fail intermittently for wide date ranges (Sentry "Fething presences failed" thrown from TaxmanController::presencesWithStartAndEndDates because the curl call returned before the presences payload was complete).

Added a public $timeout property (default 60s — unchanged behaviour for every existing caller) used by request() for CURLOPT_TIMEOUT. Callers that need a longer budget can now set $collector->timeout before issuing a request, matching the existing outputFormat / allow_error tuning pattern.